### PR TITLE
MOX-16684 upgrading jackson lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
     <compileSource>1.8</compileSource>
     <main.basedir>${project.basedir}</main.basedir>
     <ignore.test.failures>false</ignore.test.failures>
-    <jackson.version>2.10.2</jackson.version>
-    <jackson-databind.version>2.10.2</jackson-databind.version>
+    <jackson.version>2.15.2</jackson.version>
+    <jackson-databind.version>2.15.2</jackson-databind.version>
     <jaxb.version>2.3.1</jaxb.version>
     <jax-rs.version>2.0.1</jax-rs.version>
     <jersey.version>2.28</jersey.version>


### PR DESCRIPTION
found some jars in repo: https://github.com/moxionio/tinderbox2_scim_gateway/tree/stage/libs
possibly related: https://github.com/moxionio/scim2
image version `803842109edf13d65ac16c6efc6ebb6546943f3f` matches the commit hash at tag `base-2024-10-Late` in tinderbox2_scim_gateway.
details:

CVE: CVE-2020-25649
Unique ID: fgcontainer_191863333132_us-west-2-scim-scim
Location: fgcontainer_191863333132_us-west-2-scim-scim
Region: US West (Oregon)
Type: Container
Image Name:  646657783085.dkr.ecr.us-west-2.amazonaws.com/moxion-artifact-repositories-646657783085-artifact/server/scim
Image Version:  803842109edf13d65ac16c6efc6ebb6546943f3f
Solution: jackson-databind-2.10.2.jar (2.10.2): com.fasterxml.jackson.core:jackson-databind|2.6.7.4;2.9.10.7;2. |10.5